### PR TITLE
feat: add yaw_offset to COMMAND_MOVEMENT

### DIFF
--- a/LLM.md
+++ b/LLM.md
@@ -83,6 +83,7 @@ svan_simple_control/
 | `operation_mode` | `uint8` | 1–5 | Target operation mode |
 | `vel_x` | `float32` | −1.0 to 1.0 | Lateral velocity (positive = right) |
 | `vel_y` | `float32` | −1.0 to 1.0 | Longitudinal velocity (positive = forward) |
+| `yaw_offset` | `float32` | −1.0 to 1.0 | Continuous yaw mixed into movement (positive = right, negative = left, 0.0 = straight) |
 | `roll` | `float32` | −1.0 to 1.0 | Roll angle (−1 = full left, 0 = neutral, +1 = full right) |
 | `pitch` | `float32` | −1.0 to 1.0 | Pitch angle (+1 = full forward, 0 = neutral, −1 = full back) |
 | `yaw` | `uint8` | 0–2 | Yaw direction |
@@ -159,7 +160,7 @@ Interactive docs available at `<base_url>/docs`
 | `GET` | `/` | Health check |
 | `GET` | `/history` | Command history |
 | `POST` | `/mode` | Set operation mode |
-| `POST` | `/movement` | Set velocity |
+| `POST` | `/movement` | Set velocity with optional yaw offset |
 | `POST` | `/roll` | Set roll angle |
 | `POST` | `/pitch` | Set pitch angle |
 | `POST` | `/yaw` | Set yaw direction |
@@ -221,12 +222,13 @@ Interactive docs available at `<base_url>/docs`
 **Request**:
 ```json
 {
-  "vel_x": float,  // -1.0 to 1.0
-  "vel_y": float   // -1.0 to 1.0
+  "vel_x": float,      // -1.0 to 1.0
+  "vel_y": float,      // -1.0 to 1.0
+  "yaw_offset": float  // -1.0 to 1.0, optional, default 0.0 (positive = right, negative = left)
 }
 ```
 
-Values are automatically constrained to valid range.
+Values are automatically constrained to valid range. `yaw_offset` blends a continuous yaw rate into the movement command — positive values steer right, negative values steer left. Omitting the field (or setting it to `0.0`) produces straight-line motion.
 
 **Response**:
 ```json

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Both collections define a `base_url` variable. Change it to `http://10.42.4.9:88
 | `GET` | `/` | Health check — returns bridge status and mock mode warning if ROS is not connected |
 | `GET` | `/history` | List of all commands sent in the current session |
 | `POST` | `/mode` | Set operation mode (`operation_mode`: 1–5) |
-| `POST` | `/movement` | Set velocity (`vel_x`, `vel_y`: −1.0 to 1.0) |
+| `POST` | `/movement` | Set velocity (`vel_x`, `vel_y`: −1.0 to 1.0; optional `yaw_offset`: −1.0 to 1.0, default 0.0) |
 | `POST` | `/roll` | Set roll angle (`roll`: −1.0 to 1.0) |
 | `POST` | `/pitch` | Set pitch angle (`pitch`: −1.0 to 1.0) |
 | `POST` | `/yaw` | Set yaw direction (`yaw`: 0=LEFT, 1=RIGHT, 2=NONE) |
@@ -204,7 +204,7 @@ Used when `command_type = 0`.
 
 ---
 
-### `vel_x` / `vel_y` (`float32`, −1.0 to 1.0)
+### `vel_x` / `vel_y` / `yaw_offset` (`float32`, −1.0 to 1.0)
 
 Used when `command_type = 1`.
 
@@ -212,6 +212,9 @@ Used when `command_type = 1`.
 | --- | --- | --- |
 | `vel_x` | Lateral | Right |
 | `vel_y` | Longitudinal | Forward |
+| `yaw_offset` | Rotational | Right (positive = turn right, negative = turn left) |
+
+`yaw_offset` blends a continuous yaw rate into the movement command. A value of `0.0` (the default) produces straight-line motion. Non-zero values steer the robot while it walks — e.g. `yaw_offset = 0.3` curves it rightward without requiring a separate `COMMAND_YAW` message.
 
 ---
 

--- a/msg/SvanCommand.msg
+++ b/msg/SvanCommand.msg
@@ -37,6 +37,7 @@ uint8 yaw
 
 float32 vel_x
 float32 vel_y
+float32 yaw_offset
 
 
 

--- a/src/bridge.py
+++ b/src/bridge.py
@@ -44,6 +44,7 @@ class OperationModeRequest(BaseModel):
 class MovementRequest(BaseModel):
     vel_x: float = Field(..., description="Velocity along X axis (-1.0 to 1.0)")
     vel_y: float = Field(..., description="Velocity along Y axis (-1.0 to 1.0)")
+    yaw_offset: float = Field(0.0, description="Yaw offset mixed into movement (+ve = right, -ve = left, -1.0 to 1.0)")
 
 
 class RollRequest(BaseModel):
@@ -110,10 +111,11 @@ async def set_operation_mode(request: OperationModeRequest):
 
 @app.post("/movement")
 async def set_movement(request: MovementRequest):
-    vel_x = constrain_value(request.vel_x)  # Constrain values
-    vel_y = constrain_value(request.vel_y)  # Constrain values
+    vel_x = constrain_value(request.vel_x)
+    vel_y = constrain_value(request.vel_y)
+    yaw_offset = constrain_value(request.yaw_offset)
 
-    cmd_data = {"command_type": "MOVEMENT", "vel_x": vel_x, "vel_y": vel_y}
+    cmd_data = {"command_type": "MOVEMENT", "vel_x": vel_x, "vel_y": vel_y, "yaw_offset": yaw_offset}
     command_history.append(cmd_data)
 
     if ros_connected:
@@ -122,10 +124,11 @@ async def set_movement(request: MovementRequest):
             cmd.command_type = SvanCommand.COMMAND_MOVEMENT
             cmd.vel_x = vel_x
             cmd.vel_y = vel_y
+            cmd.yaw_offset = yaw_offset
             command_publisher.publish(cmd)
             return {
                 "status": "ok",
-                "message": f"Set movement: vel_x={vel_x}, vel_y={vel_y}",
+                "message": f"Set movement: vel_x={vel_x}, vel_y={vel_y}, yaw_offset={yaw_offset}",
             }
         except Exception as e:
             raise HTTPException(
@@ -134,7 +137,7 @@ async def set_movement(request: MovementRequest):
     else:
         return {
             "status": "mock",
-            "message": f"Set movement: vel_x={vel_x}, vel_y={vel_y} (MOCK MODE)",
+            "message": f"Set movement: vel_x={vel_x}, vel_y={vel_y}, yaw_offset={yaw_offset} (MOCK MODE)",
         }
 
 

--- a/src/hardware.py
+++ b/src/hardware.py
@@ -77,7 +77,7 @@ def set_operation_mode(mode: int):
     command_publisher.publish(current_joystick_data)
 
 
-def set_velocity(vel_x: float = 0.0, vel_y: float = 0.0):
+def set_velocity(vel_x: float = 0.0, vel_y: float = 0.0, yaw_offset: float = 0.0):
     global current_operation_mode, current_joystick_data
     if vel_x == 0.0 and vel_y == 0.0:
         if current_operation_mode == SvanCommand.MODE_TROT:
@@ -89,9 +89,16 @@ def set_velocity(vel_x: float = 0.0, vel_y: float = 0.0):
 
     vel_x = constrain_value(vel_x + OFFSET_VELOCITY_X)
     vel_y = constrain_value(vel_y + OFFSET_VELOCITY_Y)
-    rospy.loginfo(f"Velocity: Vel_X: {vel_x} Vel_Y: {vel_y}")
+    yaw_offset = constrain_value(yaw_offset)
+    rospy.loginfo(f"Velocity: Vel_X: {vel_x} Vel_Y: {vel_y} Yaw_Offset: {yaw_offset}")
     current_joystick_data.data[1] = vel_x
     current_joystick_data.data[2] = vel_y
+    if yaw_offset > 0:
+        current_joystick_data.data[5] = abs(yaw_offset)
+        current_joystick_data.data[6] = 0.0
+    else:
+        current_joystick_data.data[6] = abs(yaw_offset)
+        current_joystick_data.data[5] = 0.0
     command_publisher.publish(current_joystick_data)
 
 
@@ -167,9 +174,9 @@ def handle_new_command(command: SvanCommand):
     # linear movement
     elif command.command_type == SvanCommand.COMMAND_MOVEMENT:
         rospy.logdebug(
-            f"Setting Velocity: Vel_X: {command.vel_x} Vel_Y: {command.vel_y}"
+            f"Setting Velocity: Vel_X: {command.vel_x} Vel_Y: {command.vel_y} Yaw_Offset: {command.yaw_offset}"
         )
-        set_velocity(vel_x=command.vel_x, vel_y=command.vel_y)
+        set_velocity(vel_x=command.vel_x, vel_y=command.vel_y, yaw_offset=command.yaw_offset)
 
     # vertical height
     elif command.command_type == SvanCommand.COMMAND_HEIGHT:

--- a/src/sim.py
+++ b/src/sim.py
@@ -57,7 +57,7 @@ def set_operation_mode(mode: int):
     command_publisher.publish(current_key_data)
 
 
-def set_velocity(vel_x: float = 0.0, vel_y: float = 0.0):
+def set_velocity(vel_x: float = 0.0, vel_y: float = 0.0, yaw_offset: float = 0.0):
     global current_operation_mode, current_key_data
     if vel_x == 0.0 and vel_y == 0.0:
         if current_operation_mode == SvanCommand.MODE_TROT:
@@ -69,9 +69,11 @@ def set_velocity(vel_x: float = 0.0, vel_y: float = 0.0):
 
     vel_x = constrain_value(vel_x)
     vel_y = constrain_value(vel_y)
-    rospy.loginfo(f"Velocity: Vel_X: {vel_x} Vel_Y: {vel_y}")
+    yaw_offset = constrain_value(yaw_offset)
+    rospy.loginfo(f"Velocity: Vel_X: {vel_x} Vel_Y: {vel_y} Yaw_Offset: {yaw_offset}")
     current_key_data.data[1] = vel_x
     current_key_data.data[2] = vel_y
+    current_key_data.data[5] = yaw_offset
     command_publisher.publish(current_key_data)
 
 
@@ -142,9 +144,9 @@ def handle_new_command(command: SvanCommand):
     # linear movement
     elif command.command_type == SvanCommand.COMMAND_MOVEMENT:
         rospy.logdebug(
-            f"Setting Velocity: Vel_X: {command.vel_x} Vel_Y: {command.vel_y}"
+            f"Setting Velocity: Vel_X: {command.vel_x} Vel_Y: {command.vel_y} Yaw_Offset: {command.yaw_offset}"
         )
-        set_velocity(vel_x=command.vel_x, vel_y=command.vel_y)
+        set_velocity(vel_x=command.vel_x, vel_y=command.vel_y, yaw_offset=command.yaw_offset)
 
     # vertical height
     elif command.command_type == SvanCommand.COMMAND_HEIGHT:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the `yaw_offset` feature from the reference `hardware.py` / `bridge.py` snippets into the repository. `yaw_offset` lets callers blend a continuous in-place yaw rate directly into a `COMMAND_MOVEMENT` message, eliminating the need for a separate `COMMAND_YAW` + tiny-nudge workaround when curving during locomotion.

## Changes

### `msg/SvanCommand.msg`
- Added `float32 yaw_offset` field (used when `command_type = COMMAND_MOVEMENT`).

### `src/hardware.py`
- `set_velocity()` now accepts `yaw_offset: float = 0.0`.
- Positive values write to `data[5]` (yaw-right channel) and zero `data[6]`; negative values do the reverse — consistent with the existing `set_yaw()` one-hot encoding used by hardware.
- `handle_new_command()` passes `command.yaw_offset` through.

### `src/sim.py`
- `set_velocity()` now accepts `yaw_offset: float = 0.0`.
- Writes the signed value directly to `data[5]` — consistent with the existing `set_yaw()` signed single-index encoding used by the sim.
- `handle_new_command()` passes `command.yaw_offset` through.

### `src/bridge.py`
- `MovementRequest` gains an optional `yaw_offset` field (default `0.0`, −1.0 to 1.0).
- `set_movement()` constrains and forwards `yaw_offset` on the `SvanCommand`, and includes it in response messages and command history.

### `README.md`
- Updated `/movement` endpoint row.
- Expanded `vel_x / vel_y` message-reference section to cover `yaw_offset`.

### `LLM.md`
- Added `yaw_offset` row to the fields table.
- Updated `/movement` endpoint row and request/response schema.

## Behaviour

| `yaw_offset` value | Effect |
|---|---|
| `0.0` (default) | Straight-line motion, no change from previous behaviour |
| `> 0` (e.g. `0.3`) | Steers right while walking |
| `< 0` (e.g. `-0.3`) | Steers left while walking |

Backwards compatible — existing callers that omit `yaw_offset` receive `0.0` by default.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afeee39b-e504-4708-8d83-2ab4e61e61ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afeee39b-e504-4708-8d83-2ab4e61e61ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

